### PR TITLE
Expanded ini options

### DIFF
--- a/designer/mediasettingswidget.ui
+++ b/designer/mediasettingswidget.ui
@@ -122,9 +122,6 @@
      <property name="text">
       <string>Stop audio when file changes</string>
      </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
    <item>

--- a/designer/volumecontrolwidget.ui
+++ b/designer/volumecontrolwidget.ui
@@ -38,9 +38,6 @@
         <property name="singleStep">
          <double>0.100000000000000</double>
         </property>
-        <property name="value">
-         <double>10.000000000000000</double>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">

--- a/qt_ui/media_settings_widget.py
+++ b/qt_ui/media_settings_widget.py
@@ -24,6 +24,7 @@ from net.media_source.mpc import MPC
 from qt_ui.models.script_mapping import FunscriptTreeItem, ScriptMappingModel
 from qt_ui.widgets.table_view_with_combobox import ComboBoxDelegate, ButtonDelegate
 from qt_ui.models import funscript_kit, additional_search_paths
+from qt_ui import settings
 
 
 class _MediaSettingsWidget(type(QtWidgets.QWidget), type(Ui_MediaSettingsWidget)):
@@ -76,6 +77,8 @@ class MediaSettingsWidget(QtWidgets.QWidget, Ui_MediaSettingsWidget, metaclass=_
         )
         self.treeView.setItemDelegateForColumn(2, ButtonDelegate(self))
         self.treeView.setMouseTracking(True)
+
+        self.comboBox.setCurrentIndex(self.comboBox.findText(settings.media_sync_default_source.get()))
 
         header = self.treeView.header()
         header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)

--- a/qt_ui/media_settings_widget.py
+++ b/qt_ui/media_settings_widget.py
@@ -79,6 +79,7 @@ class MediaSettingsWidget(QtWidgets.QWidget, Ui_MediaSettingsWidget, metaclass=_
         self.treeView.setMouseTracking(True)
 
         self.comboBox.setCurrentIndex(self.comboBox.findText(settings.media_sync_default_source.get()))
+        self.stop_audio_automatically_checkbox.setChecked(settings.media_sync_stop_audio_automatically.get())
 
         header = self.treeView.header()
         header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)

--- a/qt_ui/media_settings_widget_ui.py
+++ b/qt_ui/media_settings_widget_ui.py
@@ -60,7 +60,6 @@ class Ui_MediaSettingsWidget(object):
         self.formLayout.setWidget(1, QtWidgets.QFormLayout.SpanningRole, self.widget_2)
         self.verticalLayout.addWidget(self.frame)
         self.stop_audio_automatically_checkbox = QtWidgets.QCheckBox(MediaSettingsWidget)
-        self.stop_audio_automatically_checkbox.setChecked(True)
         self.stop_audio_automatically_checkbox.setObjectName("stop_audio_automatically_checkbox")
         self.verticalLayout.addWidget(self.stop_audio_automatically_checkbox)
         self.treeView = TreeViewWithComboBox(MediaSettingsWidget)

--- a/qt_ui/settings.py
+++ b/qt_ui/settings.py
@@ -47,7 +47,7 @@ pulse_polarity = NonPersistentSetting('random')
 pulse_device_emulation_mode = NonPersistentSetting('continuous (best)')
 pulse_phase_offset_increment = NonPersistentSetting(0.0)
 
-volume_default = Setting('volume/default', 10.0, float)
+volume_default_level = Setting('volume/default_level', 10.0, float)
 volume_ramp_time = Setting('volume/inactivity_ramp_time', 3.0, float)
 volume_inactivity_threshold = Setting('volume/inactivity_inactive_threshold', 2.0, float)
 volume_increment_rate = Setting('volume/increment_rate', 1.0, float)

--- a/qt_ui/settings.py
+++ b/qt_ui/settings.py
@@ -100,6 +100,7 @@ device_config_waveform_type = Setting('device_configuration/waveform_type', 1, i
 device_config_min_freq = Setting('device_configuration/min_frequency', 500, float)
 device_config_max_freq = Setting('device_configuration/max_frequency', 1000, float)
 
+media_sync_default_source = Setting('media_sync/default_source', 'Internal', str)
 media_sync_mpc_address = Setting('media_sync/mpc_address', 'http://127.0.0.1:13579', str)
 media_sync_heresphere_address = Setting('media_sync/heresphere_address', '192.168.1.???:23554', str)
 media_sync_vlc_address = Setting('media_sync/vlc_address', 'http://127.0.0.1:8080', str)

--- a/qt_ui/settings.py
+++ b/qt_ui/settings.py
@@ -107,6 +107,7 @@ media_sync_vlc_address = Setting('media_sync/vlc_address', 'http://127.0.0.1:808
 media_sync_vlc_username = Setting('media_sync/vlc_username', '', str)
 media_sync_vlc_password = Setting('media_sync/vlc_password', '1234', str)
 media_sync_kodi_address = Setting('media_sync/kodi_address', 'ws://127.0.0.1:9090', str)
+media_sync_stop_audio_automatically = Setting('media_sync/stop_audio_automatically', True, bool)
 
 audio_api = Setting("audio/api-name", "", str)
 audio_output_device = Setting("audio/device-name", "", str)

--- a/qt_ui/settings.py
+++ b/qt_ui/settings.py
@@ -47,6 +47,7 @@ pulse_polarity = NonPersistentSetting('random')
 pulse_device_emulation_mode = NonPersistentSetting('continuous (best)')
 pulse_phase_offset_increment = NonPersistentSetting(0.0)
 
+volume_default = Setting('volume/default', 10.0, float)
 volume_ramp_time = Setting('volume/inactivity_ramp_time', 3.0, float)
 volume_inactivity_threshold = Setting('volume/inactivity_inactive_threshold', 2.0, float)
 volume_increment_rate = Setting('volume/increment_rate', 1.0, float)

--- a/qt_ui/volume_control_widget.py
+++ b/qt_ui/volume_control_widget.py
@@ -32,7 +32,7 @@ class VolumeControlWidget(QtWidgets.QWidget, Ui_VolumeControlForm):
         self.last_update_time = time.time()
         self.remainder = 0
 
-        self.doubleSpinBox_volume.setValue(settings.volume_default.get())
+        self.doubleSpinBox_volume.setValue(settings.volume_default_level.get())
 
         self.doubleSpinBox_volume.valueChanged.connect(self.updateVolume)
         self.doubleSpinBox_volume.valueChanged.connect(self.refresh_message)

--- a/qt_ui/volume_control_widget.py
+++ b/qt_ui/volume_control_widget.py
@@ -32,6 +32,8 @@ class VolumeControlWidget(QtWidgets.QWidget, Ui_VolumeControlForm):
         self.last_update_time = time.time()
         self.remainder = 0
 
+        self.doubleSpinBox_volume.setValue(settings.volume_default.get())
+
         self.doubleSpinBox_volume.valueChanged.connect(self.updateVolume)
         self.doubleSpinBox_volume.valueChanged.connect(self.refresh_message)
 

--- a/qt_ui/volume_control_widget_ui.py
+++ b/qt_ui/volume_control_widget_ui.py
@@ -28,7 +28,6 @@ class Ui_VolumeControlForm(object):
         self.doubleSpinBox_volume.setDecimals(2)
         self.doubleSpinBox_volume.setMaximum(100.0)
         self.doubleSpinBox_volume.setSingleStep(0.1)
-        self.doubleSpinBox_volume.setProperty("value", 10.0)
         self.doubleSpinBox_volume.setObjectName("doubleSpinBox_volume")
         self.formLayout_2.setWidget(0, QtWidgets.QFormLayout.FieldRole, self.doubleSpinBox_volume)
         self.label_target_volume = QtWidgets.QLabel(self.groupBox)


### PR DESCRIPTION
adds ways to change the following parameters in the .ini:
- default volume level
- default media source (by name as seen in combobox)
- default toggle of audio stop on file change

note: I did not generate the *_ui.py files, but I'm reasonably sure the .ui files from qtdesigner and the changes in the python are aligned