### PR TITLE
Issue #17 Fix

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 VENV_PATH="./venv"
 
-if ! [ -f "$VENV_PATH" ]; then
+if ! [ -d "$VENV_PATH" ]; then
   echo "setting up venv"
   python3 -m venv "$VENV_PATH"
 fi


### PR DESCRIPTION
run.sh should be checking for the venv as a directory, not a file.

Otherwise it will always fail and do the `venv` setup again.  