### PR TITLE
add inactivity_reduction volume setting to restim.ini

### DIFF
--- a/qt_ui/settings.py
+++ b/qt_ui/settings.py
@@ -52,6 +52,7 @@ volume_ramp_target = Setting('volume/ramp_target', 1.0, float)
 volume_ramp_increment_rate = Setting('volume/increment_rate', 1.0, float)
 volume_inactivity_time = Setting('volume/inactivity_ramp_time', 3.0, float)
 volume_inactivity_threshold = Setting('volume/inactivity_inactive_threshold', 2.0, float)
+volume_inactivity_volume = Setting('volume/inactivity_reduction', 0.0, float)
 volume_slow_start_time = Setting('volume/slow_start_time', 1.0, float)
 tau_us = Setting('volume/tau_us', 355, float)
 

--- a/qt_ui/volume_control_widget.py
+++ b/qt_ui/volume_control_widget.py
@@ -55,6 +55,7 @@ class VolumeControlWidget(QtWidgets.QWidget, Ui_VolumeControlForm):
 
         self.doubleSpinBox_inactivity_threshold.setValue(settings.volume_inactivity_threshold.get())
         self.doubleSpinBox_inactivity_ramp_time.setValue(settings.volume_inactivity_time.get())
+        self.doubleSpinBox_inactivity_volume.setValue(settings.volume_inactivity_volume.get())
         self.doubleSpinBox_ramp_rate.setValue(settings.volume_ramp_increment_rate.get())
         self.doubleSpinBox_ramp_target.setValue(settings.volume_ramp_target.get() * 100)
 


### PR DESCRIPTION
enables persistent setting of % volume reduction in pause by adding `inactivity_reduction` parameter to restim.ini settings