### PR TITLE
new axis: sensor_suppression

### DIFF
--- a/qt_ui/algorithm_factory.py
+++ b/qt_ui/algorithm_factory.py
@@ -414,6 +414,10 @@ class AlgorithmFactory:
     def get_axis_neostim_debug(self):
         return self.mainwindow.tab_neostim.axis_debug
 
+    def get_axis_sensor_suppression(self):
+        return self.get_axis_from_script_mapping(AxisEnum.SENSOR_SUPPRESSION) or \
+               self.mainwindow.sensor_suppression
+
     def get_axis_from_script_mapping(self, axis: AxisEnum) -> AbstractAxis | None:
         if not self.load_funscripts:
             return None

--- a/qt_ui/device_wizard/axes.py
+++ b/qt_ui/device_wizard/axes.py
@@ -36,6 +36,7 @@ class AxisEnum(Enum):
     INTENSITY_C = 62
     INTENSITY_D = 63
 
+    SENSOR_SUPPRESSION = 70
 
     def display_name(self) -> str:
         try:
@@ -69,6 +70,8 @@ class AxisEnum(Enum):
                 AxisEnum.INTENSITY_B: 'intensity B',
                 AxisEnum.INTENSITY_C: 'intensity C',
                 AxisEnum.INTENSITY_D: 'intensity D',
+
+                AxisEnum.SENSOR_SUPPRESSION: 'sensor suppression',
             }[self]
         except KeyError:
             return f'unknown {self.value}'
@@ -103,6 +106,8 @@ class AxisEnum(Enum):
             AxisEnum.INTENSITY_B: 'INTENSITY_B',
             AxisEnum.INTENSITY_C: 'INTENSITY_C',
             AxisEnum.INTENSITY_D: 'INTENSITY_D',
+
+            AxisEnum.SENSOR_SUPPRESSION: 'SENSOR_SUPPRESSION',
         }[self]
 
 
@@ -136,5 +141,7 @@ all_axis = [
     AxisEnum.INTENSITY_B,
     AxisEnum.INTENSITY_C,
     AxisEnum.INTENSITY_D,
+
+    AxisEnum.SENSOR_SUPPRESSION,
 ]
 

--- a/qt_ui/mainwindow.py
+++ b/qt_ui/mainwindow.py
@@ -116,6 +116,8 @@ class Window(QMainWindow, Ui_MainWindow):
         self.intensity_c = create_temporal_axis(0.0)
         self.intensity_d = create_temporal_axis(0.0)
 
+        self.sensor_suppression = create_temporal_axis(0.0)
+
         self.tcode_command_router = TCodeCommandRouter(
             self.alpha,
             self.beta,
@@ -146,6 +148,8 @@ class Window(QMainWindow, Ui_MainWindow):
             self.intensity_b,
             self.intensity_c,
             self.intensity_d,
+
+            self.sensor_suppression,
 
             # TODO: neostim
         )
@@ -395,6 +399,9 @@ class Window(QMainWindow, Ui_MainWindow):
 
         # neostim tab
         # TODO
+
+        # sensors tab
+        self.page_sensors.set_sensor_suppression_axis(algorithm_factory.get_axis_sensor_suppression())
 
         if all((not self.page_media.is_internal(),
                 self.page_media.has_media_file_loaded(),

--- a/qt_ui/models/funscript_kit.py
+++ b/qt_ui/models/funscript_kit.py
@@ -35,6 +35,8 @@ defaults = {
     AxisEnum.INTENSITY_B: ('e2', 'E2', 0, 1, True, True),
     AxisEnum.INTENSITY_C: ('e3', 'E3', 0, 1, True, True),
     AxisEnum.INTENSITY_D: ('e4', 'E4', 0, 1, True, True),
+
+    AxisEnum.SENSOR_SUPPRESSION: ('sensor_suppression', 'S1', 0, 1, True, True),
 }
 
 @dataclass

--- a/qt_ui/sensors/as5311_absolute_node.py
+++ b/qt_ui/sensors/as5311_absolute_node.py
@@ -32,6 +32,8 @@ class AS5311AbsoluteSensorNode(QWidget, SensorNodeInterface):
         self.spinbox_range = pg.SpinBox(None, 0.0, compactHeight=False, suffix='m', siPrefix=True, dec=True, minStep=1e-6, bounds=[0, None])
         self.spinbox_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', step=0.1)
         self.spinbox_decay = pg.SpinBox(None, 1.0, compactHeight=False, suffix='s', siPrefix=True, dec=True, minStep=.1, bounds=[0, None])
+        self.label_suppression = QLabel('0%')
+        self.label_suppressed_value = QLabel('0.0%')
 
         self.spinbox_threshold.valueChanged.connect(self.update_lines)
         self.spinbox_range.valueChanged.connect(self.update_lines)
@@ -43,6 +45,8 @@ class AS5311AbsoluteSensorNode(QWidget, SensorNodeInterface):
             "positive: increase volume when clenching\r\n"
             "negative: decrease volume when clenching")
         self.formLayout.addRow(label, self.spinbox_volume)
+        self.formLayout.addRow('suppression', self.label_suppression)
+        self.formLayout.addRow('suppressed value', self.label_suppressed_value)
         self.formLayout.addRow('decay', self.spinbox_decay)
 
         self.graph = pg.GraphicsLayoutWidget()
@@ -133,6 +137,10 @@ class AS5311AbsoluteSensorNode(QWidget, SensorNodeInterface):
         high = low + self.spinbox_range.value()
         self.low_marker.setValue(low)
         self.high_marker.setValue(high)
+
+    def update_suppression_display(self, suppression: float):
+        self.label_suppression.setText(f'{suppression * 100:.0f}%')
+        self.label_suppressed_value.setText(f'{self.spinbox_volume.value() * (1 - suppression):.1f}%')
 
     def save_settings(self):
         settings.sensor_as5311_absolute_threshold.set(self.spinbox_threshold.value())

--- a/qt_ui/sensors/as5311_highpass_node.py
+++ b/qt_ui/sensors/as5311_highpass_node.py
@@ -32,6 +32,8 @@ class AS5311HighPassNode(QWidget, SensorNodeInterface):
         self.spinbox_range = pg.SpinBox(None, 0.0, compactHeight=False, suffix='m', siPrefix=True, dec=True, minStep=1e-6, bounds=[0, None])
         self.spinbox_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', step=0.1)
         self.checkbox = QCheckBox()
+        self.label_suppression = QLabel('0%')
+        self.label_suppressed_value = QLabel('0.0%')
 
         self.spinbox_threshold.valueChanged.connect(self.update_lines)
         self.spinbox_range.valueChanged.connect(self.update_lines)
@@ -43,6 +45,8 @@ class AS5311HighPassNode(QWidget, SensorNodeInterface):
             "positive: increase volume when clenching\r\n"
             "negative: decrease volume when clenching")
         self.formLayout.addRow(label, self.spinbox_volume)
+        self.formLayout.addRow('suppression', self.label_suppression)
+        self.formLayout.addRow('suppressed value', self.label_suppressed_value)
         self.formLayout.addRow('absolute', self.checkbox)
 
         self.graph = pg.GraphicsLayoutWidget()
@@ -134,6 +138,10 @@ class AS5311HighPassNode(QWidget, SensorNodeInterface):
         high = low + self.spinbox_range.value()
         self.low_marker.setValue(low)
         self.high_marker.setValue(high)
+
+    def update_suppression_display(self, suppression: float):
+        self.label_suppression.setText(f'{suppression * 100:.0f}%')
+        self.label_suppressed_value.setText(f'{self.spinbox_volume.value() * (1 - suppression):.1f}%')
 
     def save_settings(self):
         settings.sensor_as5311_highpass_threshold.set(self.spinbox_threshold.value())

--- a/qt_ui/sensors/as5311_velocity_node.py
+++ b/qt_ui/sensors/as5311_velocity_node.py
@@ -34,6 +34,8 @@ class AS5311VelocitySensorNode(QWidget, SensorNodeInterface):
         self.spinbox_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', step=0.1)
         self.checkbox = QCheckBox()
         self.spinbox_decay = pg.SpinBox(None, 1.0, compactHeight=False, suffix='s', siPrefix=True, dec=True, minStep=.1, bounds=[0, None])
+        self.label_suppression = QLabel('0%')
+        self.label_suppressed_value = QLabel('0.0%')
 
         self.spinbox_threshold.valueChanged.connect(self.update_lines)
         self.spinbox_range.valueChanged.connect(self.update_lines)
@@ -45,6 +47,8 @@ class AS5311VelocitySensorNode(QWidget, SensorNodeInterface):
             "positive: increase volume when clenching\r\n"
             "negative: decrease volume when clenching")
         self.formLayout.addRow(label, self.spinbox_volume)
+        self.formLayout.addRow('suppression', self.label_suppression)
+        self.formLayout.addRow('suppressed value', self.label_suppressed_value)
         self.formLayout.addRow('decay', self.spinbox_decay)
         self.formLayout.addRow('absolute', self.checkbox)
 
@@ -144,6 +148,10 @@ class AS5311VelocitySensorNode(QWidget, SensorNodeInterface):
         high = low + self.spinbox_range.value()
         self.low_marker.setValue(low)
         self.high_marker.setValue(high)
+
+    def update_suppression_display(self, suppression: float):
+        self.label_suppression.setText(f'{suppression * 100:.0f}%')
+        self.label_suppressed_value.setText(f'{self.spinbox_volume.value() * (1 - suppression):.1f}%')
 
     def save_settings(self):
         settings.sensor_as5311_velocity_threshold.set(self.spinbox_threshold.value())

--- a/qt_ui/sensors/imu_hip_thrust_node.py
+++ b/qt_ui/sensors/imu_hip_thrust_node.py
@@ -3,7 +3,7 @@ import time
 import numpy as np
 from PySide6 import QtWidgets
 import pyqtgraph as pg
-from PySide6.QtWidgets import QVBoxLayout, QGroupBox, QFormLayout
+from PySide6.QtWidgets import QVBoxLayout, QGroupBox, QFormLayout, QLabel
 
 from device.focstim.proto_device import LSM6DSOX_SAMPLERATE_HZ
 from qt_ui.sensors import styles
@@ -39,15 +39,21 @@ class IMUHipThrustNode(QtWidgets.QWidget, SensorNodeInterface):
         self.spinbox_position = pg.SpinBox(None, 0.0, compactHeight=False, suffix='m', siPrefix=True, dec=True, minStep=1e-4)
         self.spinbox_alpha = pg.SpinBox(None, 0.0, compactHeight=False, suffix='', dec=True, minStep=0.01)
         self.spinbox_position_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', dec=True, minStep=0.1)
+        self.label_position_suppressed_value = QLabel('0.0%')
 
         self.spinbox_velocity = pg.SpinBox(None, 0.0, compactHeight=False, suffix='m/s', siPrefix=True, dec=True, minStep=1e-3)
         self.spinbox_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', dec=True, minStep=0.1)
+        self.label_suppression = QLabel('0%')
+        self.label_suppressed_value = QLabel('0.0%')
 
         self.formLayout.addRow('position amplitude', self.spinbox_position)
         self.formLayout.addRow('alpha amplitude', self.spinbox_alpha)
         self.formLayout.addRow('volume amplitude', self.spinbox_position_volume)
+        self.formLayout.addRow('suppressed value', self.label_position_suppressed_value)
         self.formLayout2.addRow('velocity amplitude', self.spinbox_velocity)
         self.formLayout2.addRow('volume amplitude', self.spinbox_volume)
+        self.formLayout2.addRow('suppression', self.label_suppression)
+        self.formLayout2.addRow('suppressed value', self.label_suppressed_value)
 
         self.graph = pg.GraphicsLayoutWidget()
         self.verticalLayout.addWidget(self.graph)
@@ -145,6 +151,11 @@ class IMUHipThrustNode(QtWidgets.QWidget, SensorNodeInterface):
 
         y2 = np.array(self.y_velo)
         self.velocity_plot_item.setData(x=x, y=y2)
+
+    def update_suppression_display(self, suppression: float):
+        self.label_suppression.setText(f'{suppression * 100:.0f}%')
+        self.label_suppressed_value.setText(f'{self.spinbox_volume.value() * (1 - suppression):.1f}%')
+        self.label_position_suppressed_value.setText(f'{self.spinbox_position_volume.value() * (1 - suppression):.1f}%')
 
     def save_settings(self):
         settings.sensor_imu_hipthrust_position.set(self.spinbox_position.value())

--- a/qt_ui/sensors/imu_velocity_node.py
+++ b/qt_ui/sensors/imu_velocity_node.py
@@ -35,6 +35,8 @@ class IMUVelocityNode(QtWidgets.QWidget, SensorNodeInterface):
         self.spinbox_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', step=0.1)
         self.checkbox = QCheckBox()
         self.spinbox_decay = pg.SpinBox(None, 1.0, compactHeight=False, suffix='s', siPrefix=True, dec=True, minStep=.01, bounds=[0, None])
+        self.label_suppression = QLabel('0%')
+        self.label_suppressed_value = QLabel('0.0%')
 
         self.spinbox_threshold.valueChanged.connect(self.update_lines)
         self.spinbox_range.valueChanged.connect(self.update_lines)
@@ -46,6 +48,8 @@ class IMUVelocityNode(QtWidgets.QWidget, SensorNodeInterface):
             "positive: increase volume when moving\r\n"
             "negative: decrease volume when moving")
         self.formLayout.addRow(label, self.spinbox_volume)
+        self.formLayout.addRow('suppression', self.label_suppression)
+        self.formLayout.addRow('suppressed value', self.label_suppressed_value)
         self.formLayout.addRow('decay', self.spinbox_decay)
 
         self.graph = pg.GraphicsLayoutWidget()
@@ -126,6 +130,10 @@ class IMUVelocityNode(QtWidgets.QWidget, SensorNodeInterface):
         high = low + self.spinbox_range.value()
         self.low_marker.setValue(low)
         self.high_marker.setValue(high)
+
+    def update_suppression_display(self, suppression: float):
+        self.label_suppression.setText(f'{suppression * 100:.0f}%')
+        self.label_suppressed_value.setText(f'{self.spinbox_volume.value() * (1 - suppression):.1f}%')
 
     def save_settings(self):
         settings.sensor_imu_velocity_threshold.set(self.spinbox_threshold.value())

--- a/qt_ui/sensors/pressure_absolute_node.py
+++ b/qt_ui/sensors/pressure_absolute_node.py
@@ -31,6 +31,8 @@ class PressureAbsoluteSensorNode(QWidget, SensorNodeInterface):
         self.spinbox_threshold = pg.SpinBox(None, 100000, compactHeight=False, suffix='Pa', siPrefix=True, dec=True, minStep=100)
         self.spinbox_range = pg.SpinBox(None, 10000, compactHeight=False, suffix='Pa', siPrefix=True, dec=True, minStep=100, bounds=[0, None])
         self.spinbox_volume = pg.SpinBox(None, 0.0, compactHeight=False, suffix='%', step=0.1)
+        self.label_suppression = QLabel('0%')
+        self.label_suppressed_value = QLabel('0.0%')
 
         self.spinbox_threshold.valueChanged.connect(self.update_lines)
         self.spinbox_range.valueChanged.connect(self.update_lines)
@@ -42,6 +44,8 @@ class PressureAbsoluteSensorNode(QWidget, SensorNodeInterface):
             "positive: increase volume when clenching\r\n"
             "negative: decrease volume when clenching")
         self.formLayout.addRow(label, self.spinbox_volume)
+        self.formLayout.addRow('suppression', self.label_suppression)
+        self.formLayout.addRow('suppressed value', self.label_suppressed_value)
 
         self.graph = pg.GraphicsLayoutWidget()
         self.verticalLayout.addWidget(self.graph)
@@ -112,6 +116,10 @@ class PressureAbsoluteSensorNode(QWidget, SensorNodeInterface):
         high = low + self.spinbox_range.value()
         self.low_marker.setValue(low)
         self.high_marker.setValue(high)
+
+    def update_suppression_display(self, suppression: float):
+        self.label_suppression.setText(f'{suppression * 100:.0f}%')
+        self.label_suppressed_value.setText(f'{self.spinbox_volume.value() * (1 - suppression):.1f}%')
 
     def save_settings(self):
         settings.sensor_pressure_absolute_threshold.set(self.spinbox_threshold.value())

--- a/qt_ui/sensors/sensor_node_interface.py
+++ b/qt_ui/sensors/sensor_node_interface.py
@@ -34,6 +34,13 @@ class SensorNodeInterface:
         """
         pass
 
+    def update_suppression_display(self, suppression: float):
+        """
+        Called periodically from the UI thread to update suppression display labels.
+        :param suppression: current sensor_suppression axis value, clamped to [0, 1]
+        """
+        pass
+
     def save_settings(self):
         """
         called before application shutdown

--- a/qt_ui/sensors_widget.py
+++ b/qt_ui/sensors_widget.py
@@ -1,8 +1,10 @@
 import functools
 import os
 import pathlib
+import time
 
-from PySide6.QtCore import Qt, Signal
+import numpy as np
+from PySide6.QtCore import Qt, Signal, QTimer
 from pyqtgraph import GraphicsLayoutWidget
 
 from funscript.collect_funscripts import Resource
@@ -121,6 +123,14 @@ class SensorsWidget(QWidget, Ui_SensorsWidget):
         self.treeWidget.itemSelectionChanged.connect(self.index_changed)
         self.checkBox.clicked.connect(self.checkbox_clicked)
 
+        self.axis_sensor_suppression = None
+        self._last_suppression = 0.0
+
+        self._suppression_display_timer = QTimer()
+        self._suppression_display_timer.setInterval(200)
+        self._suppression_display_timer.timeout.connect(self._refresh_suppression_display)
+        self._suppression_display_timer.start()
+
         self.index_changed()
         self.refresh_labels()
 
@@ -175,11 +185,33 @@ class SensorsWidget(QWidget, Ui_SensorsWidget):
 
         self.refresh_labels()
 
+    def set_sensor_suppression_axis(self, axis):
+        self.axis_sensor_suppression = axis
+
+    def _refresh_suppression_display(self):
+        suppression = self._last_suppression
+        for category_label, nodes in self.structure.items():
+            for node in nodes:
+                node.update_suppression_display(suppression)
+
     def process(self, parameters):
+        suppression = 0.0
+        if self.axis_sensor_suppression is not None:
+            suppression = float(np.clip(self.axis_sensor_suppression.interpolate(time.time()), 0, 1))
+        self._last_suppression = suppression
+
         for category_label, nodes in self.structure.items():
             for node in nodes:
                 if node.is_node_enabled():
-                    node.process(parameters)
+                    if suppression > 0 and 'volume' in parameters:
+                        volume_before = parameters['volume']
+                        node.process(parameters)
+                        if volume_before > 0:
+                            adjustment = parameters['volume'] / volume_before
+                            suppressed_adjustment = adjustment + (1 - adjustment) * suppression
+                            parameters['volume'] = volume_before * suppressed_adjustment
+                    else:
+                        node.process(parameters)
 
     def save_settings(self):
         for category_label, nodes in self.structure.items():

--- a/qt_ui/tcode_command_router.py
+++ b/qt_ui/tcode_command_router.py
@@ -51,6 +51,8 @@ class TCodeCommandRouter:
                  intensity_b: AbstractAxis,
                  intensity_c: AbstractAxis,
                  intensity_d: AbstractAxis,
+
+                 sensor_suppression: AbstractAxis,
                  ):
         self.alpha = alpha
         self.beta = beta
@@ -76,6 +78,8 @@ class TCodeCommandRouter:
         self.intensity_b = intensity_b
         self.intensity_c = intensity_c
         self.intensity_d = intensity_d
+
+        self.sensor_suppression = sensor_suppression
 
         self.mapping = {}
         self.reload_kit()
@@ -110,6 +114,8 @@ class TCodeCommandRouter:
             AxisEnum.INTENSITY_B: self.intensity_b,
             AxisEnum.INTENSITY_C: self.intensity_c,
             AxisEnum.INTENSITY_D: self.intensity_d,
+
+            AxisEnum.SENSOR_SUPPRESSION: self.sensor_suppression,
         }
 
         kit = FunscriptKitModel.load_from_settings()


### PR DESCRIPTION
When exists and is loaded, reduces the volume change % of all sensors that have volume change by the % of the axis (0 = no change, 0.25 - change reduced by 25%, 1 = change reduced to 0 - sensor disabled)

When axis is loaded and playing, the current (suppressed) value of the sensor is displayed
<img width="845" height="743" alt="image" src="https://github.com/user-attachments/assets/27a1f71e-a506-4859-ad14-460d0bc61d60" />
