### PR TITLE
Internal media source: silence at idle, drive for patterns + T-code

### DIFF
--- a/net/media_source/internal.py
+++ b/net/media_source/internal.py
@@ -1,3 +1,5 @@
+import time
+
 from PySide6.QtCore import QObject
 
 from net.media_source.interface import MediaSourceInterface, MediaConnectionState
@@ -8,9 +10,23 @@ class _InternalMeta(type(QObject), type(MediaSourceInterface)):
 
 
 class Internal(QObject, MediaSourceInterface, metaclass=_InternalMeta):
+    # Internal has no real media file. Report PLAYING only while something has
+    # been driving the output recently — external TCode traffic OR the built-in
+    # pattern generator (see mainwindow wiring). Otherwise the mute guard in the
+    # audio-gen algorithm keeps the carrier silent. Without this, selecting
+    # Internal + pressing Start with nothing driving produced a steady carrier
+    # tone on the output.
+    ACTIVITY_TIMEOUT_S = 2.0
+
     def __init__(self):
         super(Internal, self).__init__()
         self._enabled = False
+        self._last_activity_time = 0.0
+
+    def notify_activity(self, *_):
+        """Mark recent TCode / API / pattern activity. Accepts and ignores any
+        args so it can be hooked directly to Qt signals that carry payloads."""
+        self._last_activity_time = time.time()
 
     def is_internal(self) -> bool:
         return True
@@ -23,7 +39,9 @@ class Internal(QObject, MediaSourceInterface, metaclass=_InternalMeta):
         self._enabled = False
 
     def state(self) -> MediaConnectionState:
-        return MediaConnectionState.CONNECTED_AND_PLAYING
+        if time.time() - self._last_activity_time < self.ACTIVITY_TIMEOUT_S:
+            return MediaConnectionState.CONNECTED_AND_PLAYING
+        return MediaConnectionState.CONNECTED_BUT_NO_FILE_LOADED
 
     def is_enabled(self) -> bool:
         return True

--- a/qt_ui/mainwindow.py
+++ b/qt_ui/mainwindow.py
@@ -186,8 +186,30 @@ class Window(QMainWindow, Ui_MainWindow):
 
         self.output_device = None
 
+        # The Internal media source reports PLAYING only while something has been
+        # driving the output recently (see net/media_source/internal.py). Hook
+        # every drive source to its notify_activity so the carrier unmutes:
+        # external TCode (below) and the built-in pattern generator (further
+        # down). page_media + its media_sync list are created during setupUi.
+        _internal_source = next(
+            (s for s in self.page_media.media_sync if s.is_internal()),
+            None,
+        )
+
+        # The internal Live-Control pattern generator counts as activity too, so
+        # selecting Internal + Start drives output without any external T-code
+        # source (e.g. to calibrate electrodes). Only mark activity when the
+        # generated position actually CHANGES, so the mute guard still silences a
+        # static / at-rest pattern (its original anti-drone purpose).
+        self._internal_source = _internal_source
+        self._last_pattern_pos = None
+        self.motion_3.position_updated.connect(self._note_pattern_activity)
+        self.motion_4.position_updated.connect(self._note_pattern_activity)
+
         self.websocket_server = net.websocketserver.WebSocketServer(self)
         self.websocket_server.new_tcode_command.connect(self.tcode_command_router.route_command)
+        if _internal_source is not None:
+            self.websocket_server.new_tcode_command.connect(_internal_source.notify_activity)
 
         self.websocket_server.incoming_as5311_data.connect(self.page_sensors.new_as5311_sensor_data_from_network)
         self.websocket_server.incoming_imu_data.connect(self.page_sensors.new_imu_sensor_data_from_network)
@@ -200,12 +222,18 @@ class Window(QMainWindow, Ui_MainWindow):
 
         self.tcpudp_server = net.tcpudpserver.TcpUdpServer(self)
         self.tcpudp_server.new_tcode_command.connect(self.tcode_command_router.route_command)
+        if _internal_source is not None:
+            self.tcpudp_server.new_tcode_command.connect(_internal_source.notify_activity)
 
         self.serial_proxy = net.serialproxy.SerialProxy(self)
         self.serial_proxy.new_tcode_command.connect(self.tcode_command_router.route_command)
+        if _internal_source is not None:
+            self.serial_proxy.new_tcode_command.connect(_internal_source.notify_activity)
 
         self.buttplug_wsdm_client = net.buttplug_wsdm_client.ButtplugWsdmClient(self)
         self.buttplug_wsdm_client.new_tcode_command.connect(self.tcode_command_router.route_command)
+        if _internal_source is not None:
+            self.buttplug_wsdm_client.new_tcode_command.connect(_internal_source.notify_activity)
 
         self.tab_volume.set_monitor_axis([
             self.alpha,
@@ -487,6 +515,18 @@ class Window(QMainWindow, Ui_MainWindow):
 
         self.refresh_pattern_combobox()
         self.foc_device_stats.reset_utilization()
+
+    def _note_pattern_activity(self, *position):
+        """Mark internal-source activity when the pattern generator's output
+        position changes — keeps the carrier unmuted while a pattern is moving,
+        without an external T-code source. A static position marks no activity,
+        so the mute guard still silences an at-rest pattern."""
+        key = tuple(round(float(v), 4) for v in position)
+        if key != self._last_pattern_pos:
+            self._last_pattern_pos = key
+            src = getattr(self, "_internal_source", None)
+            if src is not None:
+                src.notify_activity()
 
     def pattern_selection_changed(self, index):
         pattern = self.comboBox_patternSelect.currentData()


### PR DESCRIPTION
## Problem

Selecting the **Internal** media source and pressing Start emits a steady
carrier tone even when nothing is driving the output, because
`Internal.state()` unconditionally returns `CONNECTED_AND_PLAYING`. The
mute guard in the audio-gen algorithm therefore never engages for the
Internal source.

Conversely, anyone who *fixes* that idle tone by gating Internal on
activity then finds the **built-in pattern generator no longer drives the
electrodes** — it doesn't mark itself as activity, so Internal reports
"not playing" and the carrier is muted. That makes Internal + a pattern
(e.g. for electrode calibration) produce no output.

## Change

Gate `Internal.state()` on recent activity, and have every drive source
mark activity:

- **External T-code** — websocket / TCP-UDP / serial / buttplug, via the
  existing `new_tcode_command` signal.
- **Built-in pattern generator** — `motion_3` / `motion_4`, via their
  existing `position_updated` signal, but only when the emitted position
  actually *changes*. A static / at-rest pattern marks no activity, so
  the carrier still goes quiet at true idle (the anti-drone behavior).

No change to pattern output, timing, or shapes — patterns emit exactly as
before; this only governs the Internal source's reported play state.

## Result

- Internal is silent at true idle (no surprise carrier tone).
- A moving built-in pattern drives the electrodes with no external T-code
  stream — useful for calibration.
- External T-code drives as it always has.

Two files, +59/-1.
