### PR TITLE
Add an app_id for Wayland desktops

### DIFF
--- a/qt_ui/mainwindow.py
+++ b/qt_ui/mainwindow.py
@@ -731,6 +731,9 @@ def run():
     sys.excepthook = excepthook
 
     app = QApplication(sys.argv)
+    wayland_app_id = os.environ.get("RESTIM_APP_ID","restim")
+    app.setDesktopFileName(wayland_app_id)
+    app.setApplicationName(wayland_app_id)
     win = Window()
     win.show()
     sys.exit(app.exec())


### PR DESCRIPTION
This is a very simple quality of life fix for people who run a Wayland desktop on Linux.

Python programs by default do not set a Wayland app-id, so the desktop environment sees restim as a program called `python` and not as a program called `restim`. The consequence of this is that if you launch restim from a custom `restim.desktop` file and place it in the application launcher of your desktop environment of choice, you get two icons in the launchbar: the launch icon and the active window, and they don't merge.

I included the option of overriding the app-id with the `RESTIM_APP_ID` environment variable. This is handy for me, as I maintain two separate restim configurations: restim-wave and restim-pulse, and this allows me to distinguish the two.